### PR TITLE
Implement RAG chatbot

### DIFF
--- a/chatbot/app.py
+++ b/chatbot/app.py
@@ -1,37 +1,16 @@
-import time
 import gradio as gr
+import requests
 
 
-table = {
-    "How many Cases are there on Participedia?":
-        "There are currently 2263 Cases on Participedia.",
-    "How many Methods are there on Participedia?":
-        "There are currently 373 Methods on Participedia.",
-    "How many Organizations are there on Participedia?":
-        "There are currently 858 Organizations on Participedia.",
-    "How many Collections are there on Participedia?":
-        "There are currently 20 Collections on Participedia.",
-    "How many Countries are there on Participedia?":
-        "There are currently 159 Countries on Participedia.",
-}
-
-def echo(message, history):
-    answer = table.get(message)
-    if not answer:
-        answer = ("I currently don't have answer to your question yet, "
-                  "but I keep updating myself with Participedia's dataset, "
-                  "and I would probably have the answer in the future. "
-                  "Please reset this chat and try another example.")
-    answer = answer.split()
-    for i in range(len(answer)):
-        time.sleep(0.2)
-        yield ' '.join(answer[:i+1])
+def ask(message, history):
+    response = requests.post(
+        url='http://localhost:5000/ask',
+        json={'question': message}
+    )
+    response.raise_for_status()
+    return response.json()['answer']
 
 
 if __name__ == '__main__':
-    demo = gr.ChatInterface(
-        fn=echo,
-        type="messages",
-        examples=list(table.keys()),
-        title="Participedia Bot Demo")
+    demo = gr.ChatInterface(fn=ask, type="messages", title="Participedia Question Answering Bot")
     demo.launch()

--- a/chatbot/llm_rag_demo.ipynb
+++ b/chatbot/llm_rag_demo.ipynb
@@ -1,0 +1,676 @@
+{
+ "cells": [
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "# Components",
+   "id": "778b1dc70a2d0ae9"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "## Chat model",
+   "id": "774cdd595638dbc7"
+  },
+  {
+   "cell_type": "code",
+   "id": "initial_id",
+   "metadata": {
+    "collapsed": true,
+    "ExecuteTime": {
+     "end_time": "2024-12-06T03:17:35.715415Z",
+     "start_time": "2024-12-06T03:17:34.041944Z"
+    }
+   },
+   "source": [
+    "from langchain_ollama import ChatOllama\n",
+    "\n",
+    "llm = ChatOllama(model=\"llama3.1\")"
+   ],
+   "outputs": [],
+   "execution_count": 1
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "## Embedding model",
+   "id": "809c1113e4f977c8"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-06T03:17:38.050932Z",
+     "start_time": "2024-12-06T03:17:37.623014Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "from langchain_ollama import OllamaEmbeddings\n",
+    "\n",
+    "embeddings = OllamaEmbeddings(model=\"mxbai-embed-large\")"
+   ],
+   "id": "49482efc5cbc7044",
+   "outputs": [],
+   "execution_count": 2
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "## Vector store",
+   "id": "5bc08044f6b50031"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-06T03:17:43.919141Z",
+     "start_time": "2024-12-06T03:17:40.501479Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "import faiss\n",
+    "from langchain_community.docstore.in_memory import InMemoryDocstore\n",
+    "from langchain_community.vectorstores import FAISS\n",
+    "\n",
+    "# use a single GPU\n",
+    "res = faiss.StandardGpuResources()\n",
+    "# build a flat (CPU) index\n",
+    "cpu_index = faiss.IndexFlatL2(len(embeddings.embed_query(\"hello world\")))\n",
+    "# make it into a gpu index\n",
+    "gpu_index = faiss.index_cpu_to_gpu(res, 0, cpu_index)\n",
+    "\n",
+    "vector_store = FAISS(\n",
+    "    embedding_function=embeddings,\n",
+    "    index=gpu_index,\n",
+    "    docstore=InMemoryDocstore(),\n",
+    "    index_to_docstore_id={},\n",
+    ")"
+   ],
+   "id": "71bbc4c70cdba33e",
+   "outputs": [],
+   "execution_count": 3
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "# Indexing",
+   "id": "97f729918a2081b1"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "## Loading documents",
+   "id": "863f1d6bd5c6be05"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-06T03:17:49.452227Z",
+     "start_time": "2024-12-06T03:17:49.204725Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "from langchain_community.document_loaders.csv_loader import CSVLoader\n",
+    "\n",
+    "# combined_excel.xlsx needs to be converted to csv first\n",
+    "loader = CSVLoader(file_path=\"./combined_excel.csv\", autodetect_encoding=True)\n",
+    "docs = loader.load()\n",
+    "\n",
+    "print(f\"Total number of documents: {len(docs)}\")"
+   ],
+   "id": "688b1faa64536536",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total number of documents: 3276\n"
+     ]
+    }
+   ],
+   "execution_count": 4
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-04T21:07:31.812927Z",
+     "start_time": "2024-12-04T21:07:31.809174Z"
+    }
+   },
+   "cell_type": "code",
+   "source": "print(docs[0].page_content)",
+   "id": "9206c6bcd22e311f",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resources: cases\n",
+      "body: Problems and Purpose  The  Citizens' Assembly  on Electoral Reform was a body created by the government of British Columbia, Canada. The Assembly was charged with investigating and recommending changes to improve the electoral system of the province. The body was composed of 160 citizens selected at random from throughout the province. These members met approximately every other weekend for one year to deliberate about alternative voting arrangements. After issuing their recommendations, the question would be put to the electorate-at-large in a  referendum  held concurrently with the 2005 provincial election.  Background History and Context  In 2004, 160 randomly selected residents of the province of British Columbia, Canada, participated in a bold and innovative experiment in deliberative democracy. They formed a Citizens’ Assembly whose mandate was to analyze the electoral system and, if warranted, design a new electoral law for the province. For the first time in modern history, the task of creating an electoral system was given to ordinary citizens rather than politicians or experts. Decisions about the rules of the political game — including the geographic delineation of electoral districts, rules about campaign financing, and voting systems such as plurality election and proportional representation — are frequently made by legislative bodies. One danger is that sitting legislatures will choose rules that advance their individual or party interest in re-election rather than to advance more general democratic values such as political competitiveness, diversity and voter choice, and the responsiveness of representatives.  When the province considered the question of whether to reform its electoral system from majority rule election of legislators to some form of proportional representation, the Government of British Columbia created a body called the British Columbia Citizen’s Assembly, composed of citizens from throughout the province. The hope behind the Citizens’ Assembly is that a recommendation made by ordinary citizens rather than professional politicians or political elites would produce a more fair electoral system and also be accepted as more legitimate by British Columbians.  The proposal to convene this Citizens’ Assembly was part of a package of government reforms that the Liberal party offered in its 2001 election platform. This unorthodox initiative was the party’s response to a decade of increasing dissatisfaction with the existing electoral system. In 1996, the Liberals received 42% of the vote against 39% for the New Democratic Party (NDP). The NDP, however, won a plurality of seats in the provincial legislature (39 seats compared to 33 for the Liberal Party) under this “first-past-the-post” (FPTP) electoral system. According to its rules, each electoral district (also called a “riding”) elects one representative to parliament. The candidate who wins the greatest number of votes in a district wins its seat and the other candidates (and those who voted for them) get nothing. The Liberal Party’s simultaneous popular victory and legislative defeat in 1996 underscored the difficulties of this system for many British Columbians.  Liberal leader Gordon Campbell promised to institute a Citizens’ Assembly to consider whether a change in the electoral system was needed and, if so, to design a new electoral law, should the Liberals gain power. The Liberals won in 2001 in an election that confirmed the urgency of a reform. Their 57.62% share of the popular vote granted them 77 out of 79 seats. Though the New Democratic Party won 21.56% of the vote, they controlled only two seats. The Green Party, with its 12.39% vote share, got no seats at all. The Liberals kept their promise and, in 2003, the Citizens’ Assembly was formally established.  Organizing, Supporting, and Funding Entities  The citizens' assembly was established by the Liberal government and allocated $5.5 million in public funds. An Assembly chairman and other key staff were also appointed to carry out preparatory work necessary for the Assembly to convene in January 2004. From January to November 2004, the 160 assembly members met, in three distinct phases, to deliberate about the existing electoral system and alternatives to it. The Assembly’s mandate, however, did not include the ultimate power to select a new system. The Assembly could formulate a detailed proposal and the citizens of British Columbia—not the legislature—would have the final say through a  popular referendum .  Participant Recruitment and Selection  Though an unorthodox body, the Citizens’ Assembly was a creature of normal legislative authorization. In 2002, the newly elected provincial government appointed a former legislator and Liberal party leader to recommend a format for the assembly. Months after his report was submitted, the government appointed the assembly’s chair, and submitted a motion to the Legislature to establish the assembly. On April 2003, the motion was approved unanimously, and a special committee of the legislature was set up to monitor the set up of the assembly and its work.  The assembly would include 158 British Columbia residents (two for each riding), be staffed by a chair and secretariat, work all through the year 2004, and be granted a budget of $5.5 million to conduct this business. Premier Gordon Campbell remarked that, \"for the first time in our nation's history, we are providing voters with the opportunity to decide for themselves how we elect our MLAs — how they should elect those who sit in the legislature to represent them”.  Its enacting legislation required that, the Citizens’ Assembly \"be broadly representative of the adult population of British Columbia, particularly respecting age, gender, and geographical distribution.” There are many ways to produce a body that “represents” the whole population. The Citizens' Assembly was to be chosen through modern techniques of random selection that improve upon the ancient method of election by lot. A list of names was to be  randomly selected  from the provincial voters’ list, with an equal number drawn from the 79 ridings. An equal number of men and women were to be drawn and selection methods aimed to mirror the age distribution of citizens over 18 in the province. Participants would be paid an honorarium of $150 per day; daycare, transportation and accommodation were also provided to make it easier for people with lower incomes and those who lived far from Vancouver to participate. This Assembly, designers thought, would ensure a balance of interests and incorporate the views of ordinary citizens into basic electoral law.  The painstaking selection began in August 2003 and continued through December. First, the voter registry for each riding was updated. Then 100 males and 100 females were randomly selected from the list for each of the 79 ridings yielding a total of 15,800 names. This sample was stratified by age cohort as well as gender in each riding. The people selected in this random draw were all invited by letter to participate in selection meetings in their ridings. Due to a low response rate, additional names were drawn in some districts. In all, over 23,000 invitation letters were sent. From these, approximately 1,700 voters expressed interest in participating in the Citizens’ Assembly, and 964 ended up attending selection meetings that provided information on the assembly’s mandate and operations, on the commitment required of members, and the selection process. Of those who attended, 158 were randomly selected, one male and one female elector per district. The names of those who had participated in selection meetings but had not been drawn were kept in case the Assembly required substitutes. This process produced no aboriginal representation, and later one male and one female aboriginal citizen were added to the Assembly by random draw from those who had attended the meetings but had not been selected. At the end of this process, the Assembly was composed of 160 members and a chair who voted only in the event of a tie.  The legislative mandate aimed to create a body that would be independent as well as representative. The Citizens’ Assembly was charged with analyzing electoral models for British Columbia with the only constraint that any recommendations be consistent with the Constitution of Canada and the Westminster parliamentary system. The Citizens’ Assembly could recommend retaining the status quo or it could propose a single detailed alternative electoral system consistent with this broad constraint. By design, the  deliberations  of the Assembly were to be insulated from interference by political parties. Furthermore, the materials and experts were to be chosen so that no particular alternative received special emphasis or preference.  The Assembly had the power to propose a system, but not to make it into law. The Assembly’s recommendations were due by the end of December 2004. If it offered a new model, the proposal would be submitted to popular referendum on May 17, 2005 at the time of the provincial general election. The referendum would pass only if it received a “double-majority” approval of at least 60% of the votes cast throughout the province and a simple majority approval in at least 60% of the 79 ridings (that is, at least 50% + 1 of the votes in at least 48 ridings). Some criticized the required majority as too stringent, but others contended that a super-majority was appropriate to ratify a measure of constitutional importance and to ensure adequate support from the entire province.  Methods and Tools UsedCitizens' Assembly  — 160 participants, 158 through random selection, 2 (indigenous) through targeted recruitment  Learning phase — small group discussions/debates, large-group lecture sessions with invited experts, plenary discussions and knowledge sharing.Public HearingsWhat Went On: Process, Interaction, and ParticipationThe Learning PhaseSome political scientists devote their entire careers to understanding various voting systems and their consequences. Most members, by contrast, felt that they knew relatively little about electoral systems. As they started, they gave themselves an average of only 4.3 on a ten-point scale when asked what they knew about voting rules. Therefore, the first order of business was for the Assembly’s 160 members to master the fundamentals of this field.  During an initial “learning phase,” the Assembly convened for six weekends (Saturday and Sunday morning) from January to late March. During these meetings, experts lectured members on electoral models in large-group sessions, members met in small groups to discuss and debate what they heard and read, and then they met in plenary to share their views. Members were randomly assigned to small groups of 10-15 members each, and groups changed every weekend to favor team building.  The lecturers and topics of the learning phase were carefully selected by Assembly staff to be impartial. The curriculum plan was reviewed by a special committee of academics and experts. Canadian as well as international political scientists instructed the groups on topics such as the role of parliament, elections and the five major families of electoral systems (majority, plurality, party list, single transferable vote, and mixed). Written materials were provided to Assembly members and senior political science graduate students facilitated their small group discussions.  During this phase, important steps were taken to develop relationships, communicative norms, and esprit de corps among participants. Members stayed in a hotel adjacent to the Assembly Hall, ate all their meals together, and often organized social events when the Assembly was not in session. They were also asked to articulate the values that should guide and regulate their interactions with one another. The assembly adopted by  consensus  values such as respect of all opinions, integrity, open-mindedness and inclusivity.The Public Hearings PhaseThe learning phase was followed by a public hearings phase that ran from May to June 2004. Individual Assembly members hosted some fifty hearings across the province to listen to their fellow citizens’ opinions on electoral reform and gather feedback from the general public. Members went to some in their home area but also attended hearings in other areas to hear what people in different communities thought. In these meetings, Assembly members also heard the arguments of interest groups, advocacy organizations and political parties, ranging from the British Columbia Nurses’ Union to the B.C. Green Party. Scribes recorded these sessions and produced summaries of all presentations. Approximately 3,000 people participated in public hearings that drew anywhere from 20 to 150 participants apiece. Besides public hearings, the Assembly also received some 1,600 written submissions that members read on-line or in print. Overall, the hearings highlighted support for a more proportional system, mainly some kind of mixed member proportional (MMP) system. The status quo majoritarian system received limited support in these hearings.The Deliberation PhaseThe third and final “ deliberation  phase” of the Assembly unfolded between September and November 2004. Up until this point, members had been asked mainly to learn and then listen. In the final three short months, however, they had to develop a recommendation for the electoral system that best suited British Columbia. During deliberation, members were prompted to identify the most important values for their electoral system. Fair results, understood as proportionality between votes and seats, local representation, and voter choice emerged as the three most important values. These became the criteria that members would use to judge alternatives.  From the beginning of the deliberation phase, it was clear that few supported the status quo FPTP system and that most favored some form of proportional representation. In relatively short order, the Assembly narrowed the field to two alternatives: the single transferable vote (STV) and the mixed member proportional (MMP) system. Members then spent two weekends (one on each) developing the best version of each system for British Columbia. Under the STV system, voters don’t select just one candidate on a ballot, but rank them from most to least favorite. For each district, there is a threshold of votes above which any candidate will be elected. In case a voter’s first choice candidate is not elected, or receives enough votes to be elected in a district, his or her vote is transferred to second choice. In this way, no vote is “wasted” and results are proportional to electoral support. The MMP system combines local representation and proportionality by assigning electors multiple votes. In New Zealand’s variant, for example, each voter casts two votes. One of these elects one representative in their district with a plurality winner (as with the first-past-the-post system). The voter chooses a party with his second vote, and candidates are assigned parliamentary seats proportionally according to party lists.  The final choice came after thoughtful deliberation on the two options, and their characteristics. Throughout the deliberation phase, members gave important reasons to support their system of choice. Some favored MMP because it balances local and proportional representation, combining “the best of both worlds” and expanding voter choice. According to a member “a lot of people don’t vote for lack of choice” and a more proportional system could reduce voter apathy by allowing small parties to emerge, thus creating more options for different constituencies. MMP would be particularly beneficial for individuals who live in areas where an ideology dominates because it allows “people who have alternative views […] to voice those views.” Another argued that “there’s a better chance with MMP for women and minorities to get elected.” If MMP gives electors more option, with a district representative and a list vote, it also gives parties too much power, and uncontested seats, whereas “there is no safe seat under STV.”  Some preferred STV over MMP because it focuses more on individual candidates and “reduces party discipline.” A member in support of STV reminded the group that much of the disillusionment with politics stemmed from excessive party power: “why are we here? We are here because of the problems created by parties, not by candidates […] here’s our chance to change it.” Members of the sparsely populated northern region were especially concerned with local representation and favored STV, with its smaller districts, over MMP. Observers report that the quality of these deliberations was generally quite high. Members showed a nuanced understanding of electoral systems, acknowledged the advantages and disadvantages of both options, and tried to reduce disagreements.  After months of deliberation, the Assembly used secret ballots to tally its members’ judgments. In the first vote, the group selected the STV system over MMP (123 votes for STV against 31 for MMP). In the final vote, the overwhelming majority (146 in favor, 7 against) supported a recommendation that a referendum be put to the citizens of British Columbia that STV replace the current single-member plurality system.  Influence, Outcomes, and Effects  In October 2004, the Assembly recommended replacing the province's existing \"First Past the Post\" (FPTP) system with a \"Single Transferable Vote\" (STV) system: this recommendation was  put to the electorate-at-large in a referendum held concurrently with the 2005 provincial election . The referendum required approval by 60% of votes and simple majorities in 60% of the 79 districts in order to pass. The referendum was held on May 17, 2005, asking BC residents to answer yes or no to the following question: “Should British Columbia change to the BC-STV electoral system as recommended by the Citizens’ Assembly on Electoral Reform?” Although the Citizens’ Assembly was the Liberal Party premier’s initiative, only the Green Party endorsed the STV proposal. Even there, the Greens preferred MMP to STV, but preferred STV to the status quo. Gordon Campbell praised the Assembly as a process that could be employed in other areas such as health and education, but the political parties remained largely silent regarding the merits and weaknesses of the proposal.  British Columbians could learn about the Assembly’s work by watching the recordings of the Assembly’s sessions, which broadcast repeatedly over the provincial legislature’s television service. The Assembly also maintained constant communication with the media, and had a continually updated website, which, by November 2004, had attracted over 47,000 visitors from 148 countries. In March 2005, a “NO” coalition formed, comprising personalities from across the political spectrum, to counter the “YES” coalitions (which included a group formed by former Assembly members). Despite these public information campaigns, polling evidence suggested that by the time of the referendum, about half of British Columbia voters were unaware of the referendum.  Although many voters reported limited knowledge of the referendum question on the days preceding the vote, the STV proposal nearly passed. It won by simple majority in 77 out of 79 ridings, easily passing one hurdle of the double super-majority requirement. But it won 57.4% of the total votes cast, falling a few points short of the required 60%. This result surprised many media observers who predicted that the STV proposal would clearly lose. A majority of votes, albeit close to the required percentage, was not enough to scrap the current system. The leaders of the three major parties, the Liberals, the NDP and the Greens, all agreed that the referendum results clearly signaled the public’s discontent. As Premier Gordon Campbell remarked, \"There's a real hunger to move and look at ways of improving our system […] I've been a clear advocate of that and I'm going to look at that in different ways in the future.\" The NDP leader proposed that a new Citizens’ Assembly should look at a new model; others suggested that the legislature should examine the issue. Many other Canadian provinces started working on electoral reform, and  Ontario launched a similar citizen assembly , led by a judge and followed by a referendum.  In September 2005, the government committed to re-submit the STV system to a referendum in November 2008, so that a possible new system could be used for the 2009 provincial elections. Cognizant of some of the reasons that led to the referendum’s defeat, the Liberal government promised funding for opponents and supporters of the STV system to make the cases for and against before the public of British Columbia. In addition, the government asked the Electoral Boundaries Commission to provide a map of ridings under the proposed STV system. Furthermore, the wording of the 2008 referendum question was to be crafted by government and debated by the legislature. But owing to the costs of holding a separate election as well as to accommodate the work schedule of the Electoral Boundaries Commission, the government delayed the referendum until May 2009, when it could be combined with the general election. This time the province's voters defeated the STV proposal with only 38.82% voting in favour.  Analysis and Lessons Learned  Though the Citizens’ Assembly ingeniously delegated important powers to ordinary citizens, it also attracted some criticisms regarding its design and operation. Random selection of members was meant to make the body representative of the public at large, but citizens were not obliged to participate, as they are in  legal juries . Instead, they were free to decline, so it is likely that many of the members who accepted were more active and civic-minded than the population at large. Participating in the Assembly might also have been more appealing to reformists than to those who were satisfied with the status quo. The selection process insured equal representation by geography, gender, and age group, but not ethnicity, aboriginal status, or socio-economic status. If the selection criteria granted equal representation to men and women, why should it not also ensure that also the voices of disadvantaged groups or of citizens of specific ethnic origin be represented? Finally, it remains unclear whether members felt they were representing their personal views, their districts, what emerged from the hearings, or the province at large. Would the Assembly have made different decisions with different selection mechanisms and notions of representation?  In terms of equality of the deliberations, inevitably, some members spoke more than others, with interventions from men outnumbering those of women or minorities. Although the chair encouraged first-time speakers to engage, more formal inclusion rules could have levelled the playing field for all participants.  Other critics suspect that the process of deliberation was consciously or unconsciously steered by staff. Members composed neither the structure of the Assembly’s  deliberations , its timing, nor its agenda. Staff decisions regarding these factors, as well as the educational materials and the selection of experts who spoke to Assembly members, may have biased their deliberations. Additionally, members had no choice over the priorities of reform, but were restricted by their mandate to focus solely on the electoral law, neglecting other important elements, such as electoral districts, or campaign finance.  The deliberation phase was particularly complicated because the Assembly mandate required that the different options that had been explored in previous phases had to be narrowed down and eventually coalesce into one proposal. The process of selecting the desirable characteristics of a model, for example, was hastened and issues such as women representation received less attention than some wished. The group ended up selecting the three characteristics that were at the top of the lecturer’s list of desirable features of electoral models. Similarly, it was unclear whether the Assembly had the authority to modify the number of electoral districts and the number of parliamentary seats, which would have been required to adopt the MMP system. The Assembly chair clarified that the number of seats could not be altered, which might have prompted members to select the STV system because it required less change. It appears that more time was devoted to illustrating the STV system, while the technical details of applying the MMP model to British Columbia were left unexplored. The tension between exploring options and reaching consensus around a model emerged during the deliberation phase, and it remains unclear whether members would have favored the MMP system had they had more time to work through its complexities.  In the end, the referendum, although supported by a substantial majority of the population, did not pass. Perhaps it did not deserve to pass. Despite its potential problems, there is little doubt that the deliberations of the Assembly were rich and serious. The larger public debate about the STV proposal was anemic by comparison. Although the government provided Assembly members with ample opportunities to become experts in electoral systems, it did not make a comparable investment to educate the general public before the referendum. For the most part, political parties and politicians did not engage this quasi-constitutional question. Despite this deafening silence, the majority of citizens voted against the very system that elected their government. After that popular rebuke, one observer remarked, “the real deliberation will begin.”  See AlsoCitizens' AssemblyBritish Columbia Referendum on Electoral Reform (2005)References  Mark Warren and Hillary Pearse eds. Designing Deliberative Democracy: The British Columbia Citizens’ Assembly (Cambridge University Press, 2008).  Lang, Amy. “ But Is It For Real? The British Columbia Citizens’ Assembly as a Model of State-Sponsored Citizen Empowerment ” in Politics and Society, Vol. 35, No. 1 (2007): 35-70.  External LinksHistory of the British Columbia Citizens AssemblyOp-ED: \"Who Killed the BC-STV?\"BC Citizens' Assembly on Electoral Reform — Final ReportThe \"Know STV\" Campaign (urged 'no' vote)Simulation of 2005 Election using STV boundariesThe Citizens Assembly Blog (covers citizens assembly developments worldwide)iSolon.org's clearinghouse of citizens assembly informationNotes  The first submission of this case entry was originally published on Vitalizing Democracy as a contestant for the 2011 Reinhard Mohn Prize.\n",
+      "row_number: 0\n"
+     ]
+    }
+   ],
+   "execution_count": 5
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "## Splitting documents",
+   "id": "dd6bb8b6681d3344"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-04T21:07:40.945653Z",
+     "start_time": "2024-12-04T21:07:37.824463Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "from langchain_text_splitters import RecursiveCharacterTextSplitter\n",
+    "\n",
+    "text_splitter = RecursiveCharacterTextSplitter(\n",
+    "    chunk_size=2000,  # chunk size (characters)\n",
+    "    chunk_overlap=200,  # chunk overlap (characters)\n",
+    "    add_start_index=True,  # track index in original document\n",
+    ")\n",
+    "all_splits = text_splitter.split_documents(docs)\n",
+    "\n",
+    "print(f\"Split documents into {len(all_splits)} sub-documents.\")"
+   ],
+   "id": "eeeaa266239a510b",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Split documents into 20532 sub-documents.\n"
+     ]
+    }
+   ],
+   "execution_count": 6
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "## Storing documents",
+   "id": "bf76d37ea1242299"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-04T21:20:29.797667Z",
+     "start_time": "2024-12-04T21:07:51.975688Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "document_ids = vector_store.add_documents(documents=all_splits)\n",
+    "\n",
+    "print(document_ids[:3])"
+   ],
+   "id": "82ff3cb06e4be610",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['e2e8be83-071c-4bf7-84e6-6b9c1b6cb31d', '6ef341cd-4826-4f79-ab08-8bab7ab6e1a8', '22997f4c-accf-4f60-b367-268c0d8535d3']\n"
+     ]
+    }
+   ],
+   "execution_count": 7
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "## Saving vectors",
+   "id": "286ac756c6e23fdf"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-04T21:24:13.041362Z",
+     "start_time": "2024-12-04T21:24:12.877999Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "# convert the index from gpu-based to cpu-based just for serialization\n",
+    "vector_store.index = faiss.index_gpu_to_cpu(vector_store.index)\n",
+    "\n",
+    "vector_store.save_local(\"faiss_index\")"
+   ],
+   "id": "c3bc4fbc598a9146",
+   "outputs": [],
+   "execution_count": 14
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "## Loading vectors",
+   "id": "8aca8f44ae182aaf"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-04T21:24:23.364051Z",
+     "start_time": "2024-12-04T21:24:23.173057Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "vector_store = FAISS.load_local(\"faiss_index\", embeddings, allow_dangerous_deserialization=True)\n",
+    "\n",
+    "# convert the index from cpu-based back to gpu-based for accelerated search\n",
+    "vector_store.index = faiss.index_cpu_to_gpu(res, 0, vector_store.index)"
+   ],
+   "id": "b90ad2af3fa45c0b",
+   "outputs": [],
+   "execution_count": 15
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "# Retrieval and Generation",
+   "id": "eef4ef21e4ebdf9b"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "## Retriever",
+   "id": "78aedb605c9620c3"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-04T21:22:11.230432Z",
+     "start_time": "2024-12-04T21:22:11.226077Z"
+    }
+   },
+   "cell_type": "code",
+   "source": "retriever = vector_store.as_retriever()",
+   "id": "a0b014058225408d",
+   "outputs": [],
+   "execution_count": 8
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "## Prompt",
+   "id": "c30dd584903d18e4"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-04T21:22:14.329453Z",
+     "start_time": "2024-12-04T21:22:14.324134Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "from langchain.prompts import PromptTemplate\n",
+    "\n",
+    "# Define the prompt template for the LLM\n",
+    "prompt = PromptTemplate(\n",
+    "    template=\"\"\"You are an assistant for question-answering tasks.\n",
+    "    Use the following documents to answer the question.\n",
+    "    If you don't know the answer, just say that you don't know.\n",
+    "    Question: {question}\n",
+    "    Documents: {documents}\n",
+    "    Answer:\n",
+    "    \"\"\",\n",
+    "    input_variables=[\"question\", \"documents\"],\n",
+    ")"
+   ],
+   "id": "c314f9ab56b3c7a2",
+   "outputs": [],
+   "execution_count": 9
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "## Chain",
+   "id": "a2404be8001ada56"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-04T21:22:18.924526Z",
+     "start_time": "2024-12-04T21:22:18.920688Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "from langchain_core.output_parsers import StrOutputParser\n",
+    "\n",
+    "# Create a chain combining the prompt template and LLM\n",
+    "rag_chain = prompt | llm | StrOutputParser()"
+   ],
+   "id": "990d7f0f7aa17410",
+   "outputs": [],
+   "execution_count": 10
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "## Integration",
+   "id": "3c9b3fa75e2dc220"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-04T21:22:21.607262Z",
+     "start_time": "2024-12-04T21:22:21.603882Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "# Define the RAG application class\n",
+    "class RAGApplication:\n",
+    "    def __init__(self, retriever, rag_chain):\n",
+    "        self.retriever = retriever\n",
+    "        self.rag_chain = rag_chain\n",
+    "    def run(self, question):\n",
+    "        # Retrieve relevant documents\n",
+    "        documents = self.retriever.invoke(question)\n",
+    "        # Extract content from retrieved documents\n",
+    "        doc_texts = \"\\\\n\".join([doc.page_content for doc in documents])\n",
+    "        for i in range(len(documents)):\n",
+    "            print(f\"Document {i}: {documents[i]}\")\n",
+    "        # Get the answer from the language model\n",
+    "        answer = self.rag_chain.invoke({\"question\": question, \"documents\": doc_texts})\n",
+    "        return answer"
+   ],
+   "id": "81a03657d9d609aa",
+   "outputs": [],
+   "execution_count": 11
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "## Test",
+   "id": "3789982dd9e16581"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-04T21:22:25.339192Z",
+     "start_time": "2024-12-04T21:22:25.335709Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "# Initialize the RAG application\n",
+    "rag_application = RAGApplication(retriever, rag_chain)"
+   ],
+   "id": "62abae7be8a5da71",
+   "outputs": [],
+   "execution_count": 12
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-04T21:22:31.551789Z",
+     "start_time": "2024-12-04T21:22:27.097401Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "# Example usage 1\n",
+    "question = \"What participation methods are used in the 2015 Metro Vancouver Transportation and Transit Plebiscite?\"\n",
+    "answer = rag_application.run(question)\n",
+    "print(\"Question:\", question)\n",
+    "print(\"Answer:\", answer)"
+   ],
+   "id": "dc75801a21b54bb7",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Document 0: page_content='body: Comparative Perspectives on Planning History and Futures [PLAN 500]School of Community and Regional Planning | UBCPARTICIPATORY PLANNING ANALYSISAaron Li, Erin Grace, Charlotte Lemieux, Jamie Tseng, Emily (Young Eun) Park, Brandon ChowIntroductionThe 2015 Metro Vancouver Transportation and Transit Plebiscite was a significant event in the region's political history. It arose from a campaign promise by the British Columbia Liberal Party led by Premier Christy Clark. The decision to hold a public vote on transportation funding was an unusual case in the context of Canadian governance, as major public infrastructure projects are seldom decided by a plebiscite or referendum. This move was seen as controversial, generating debate over the appropriateness of placing complex infrastructure planning in the hands of the general public.This plebiscite is unique in the history of public participation and will be critically analyzed using Fung’s Democracy Cube (2006) and Arnstein’s Ladder of Citizen Participation, highlighting the shortfalls and missed opportunities to ensure robust, equal, and deep participation.Scope and PlanThe proposed projects under the plebiscite were diverse and aimed at enhancing the transportation network within Metro Vancouver,including the expansion of the light rail network, such as the Broadway Subway project and Light Rail Transit (LRT) in Surrey and Langley, enhancements to existing bus services, a new 4-lane Pattullo Bridge, and significant upgrades to major roads (Mayors’ Council on Regional Transportation, 2015), as shown in Figure 1. These projects aimed to address the growing challenges of the region, specifically around transportation, transit, and congestion, with the goal to enhance connectivity and facilitate smoother commutes for residents.Figure 1. Proposed projects for transportation investmentImage from Mayors’ Council on Regional Transportation, 2015Controversial Funding MechanismThe funding mechanism proposed for these' metadata={'source': 'combined_excel.csv', 'row': 2147, 'start_index': 17}\n",
+      "Document 1: page_content='electorate's concerns over increased taxation, hesitation to absorb additional financial stress, and a lack of confidence in TransLink to effectively manage and execute the proposed improvements. The rejection prompted further discussions about funding mechanisms for public transportation projects, signifying the critical role of public participation in complex infrastructure decision-making.ProcessElections BC was responsible for the execution of the 2015 plebiscite, which cost almost $5.4 million dollars (Elections BC, 2015a) and was initiated on February 12, 2015, when the Plebiscite Regulation was established (Elections BC, 2015a). The entire process of the plebiscite started on March 16, 2015, when voting package distribution began; only registered BC voters were eligible to participate. The voting method was through mail-in ballots that voters would mark and send either directly to Elections BC or through a plebiscite service office. The number of registered voters was 1,551,507 at the initial package distribution date. The initial distribution was fully delivered to all voters by March 27.The 2015 plebiscite was the first one of its kind administered by Elections BC since the 1972 “British Columbia Time Plebiscite,” which was held simultaneously with a general election where voters were asked if they were in favour of Pacific Standard Time, including Pacific Daylight Savings time. The 2015 campaign was open to 23 municipalities in the Metro Vancouver Regional District, and residents were strongly encouraged to register to vote before and during the plebiscite as they would not be eligible to participate if they were not registered to vote in the province.There were nine service offices dedicated to providing services, guidance, and registration of new voters during the voting process. They were dispersed throughout different Metro Vancouver shopping centers. Elections BC operators were available six days a week, and contact hours were extended until midnight' metadata={'source': 'combined_excel.csv', 'row': 2147, 'start_index': 3609}\n",
+      "Document 2: page_content='conclusion, the appropriateness of using a plebiscite as the participatory process of such a large-scale regional infrastructure project is questioned, as it fails to address the complexity of the many factors, such as differences in local populations, uneven benefits, and equity in engagement. Therefore, we argue that a more selective process in choosing a smaller group of people for different phases of the planning process and equipping those people with the necessary information to make informed decisions would equate to more meaningful citizen involvement and a more appropriate and equitable participatory process.ReferencesArnstein, S. R. (1969). A Ladder Of Citizen Participation.Journal of the American Institute ofPlanners  , 35(4), 216-224.https://doi.org/10.1080/01944366908977225Brueckner, J. K., Mills, E., &amp; Kremer, M. (2001). Urban Sprawl: Lessons from Urban  Economics [with Comments].  Brookings-Wharton Papers on Urban Affairs , 65–97.  http://www.jstor.org/stable/25058783Clark, H. M. &amp; CJI Research Corporation(2017). Who Rides Public Transportation.  https://www.apta.com/wp-content/uploads/Resources/resources/reportsandpublications/Documents/APTA-Who-Rides-Public-Transportation-2017.pdfCornwall, A. (2008). Unpacking ‘Participation’: models, meanings and practices.  CommunityDevelopment Journal , 43(3), 269-283.  https://doi.org/10.1093/cdj/bsn010Elections BC. (2015a). Report for the Chief Electoral Officer on the 2015 Metro VancouverTransportation and Transit Plebiscite. Retrieved December 10, 2023, fromhttps://www.elections.bc.ca/docs/rpt/2015-CEO-MVTTP-Plebiscite-Report.pdfElections BC. (2015b).Voting results: 2015 Metro Vancouver Transportation and TransitPlebiscite  . Legislative Library of British Columbia. Retrieved December 10, 2023, fromhttps://www.llbc.leg.bc.ca/public/pubdocs/bcdocs2015_2/588363/2015-plebiscite-results.pdfFung, A. (2006). Varieties of Participation in Complex Governance.PublicAdministration Review66: 66-75Gastil, J.,' metadata={'source': 'combined_excel.csv', 'row': 2147, 'start_index': 28793}\n",
+      "Document 3: page_content='A. (2006). Varieties of Participation in Complex Governance.PublicAdministration Review66: 66-75Gastil, J., &amp; Richards, R. (2013). Making Direct Democracy Deliberative through Random  Assemblies.  Politics &amp; Society ,  41 (2), 253-281.https://doi.org/10.1177/0032329213483109Hosford, K., &amp; Winters, M. (2022).How the Canadian Population Gets to Work  .https://mobilizingjustice.ca/how-the-canadian-population-gets-to-work/Laclaire, L. [cityofvancouer] (2015).I am Lon LaClaire, manager of Strategic Transportation Planning for the City of Vancouver. AMA![online forum post] Reddit. https://www.reddit.com/r/vancouver/comments/2y1xw9/i_am_lon_laclaire_manager_of_strategic/Mayors’ Council on Regional Transportation (2015). Regional Transportation Investments - aVision for Metro Vancouver. Retrieved December 10, 2023, from https://drive.google.com/file/d/1uKGiwlS2PgaWC2Ke6qC5z8gNGmt8QXVn/view.https://data.london.gov.uk/dataset/transport-crime-london?q=crime%20traMichels, A. (2011). Innovations in democratic governance: how does citizen participationcontribute to a better democracy?International Review of Administrative Sciences  , 77(2), 275-293.https://doi.org/10.1177/0020852311399851Pawson, C. (2015). Voting begins in Metro Vancouver transit referendum.CB' metadata={'source': 'combined_excel.csv', 'row': 2147, 'start_index': 30682}\n",
+      "Question: What participation methods are used in the 2015 Metro Vancouver Transportation and Transit Plebiscite?\n",
+      "Answer: The participation methods used in the 2015 Metro Vancouver Transportation and Transit Plebiscite included:\n",
+      "\n",
+      "* Mail-in ballots for voters to mark and send directly to Elections BC or through a plebiscite service office.\n",
+      "* Nine service offices dedicated to providing services, guidance, and registration of new voters throughout different Metro Vancouver shopping centers.\n",
+      "* Extended contact hours until midnight at the service offices.\n",
+      "\n",
+      "The participation process was open to 23 municipalities in the Metro Vancouver Regional District, and residents were strongly encouraged to register to vote before and during the plebiscite.\n"
+     ]
+    }
+   ],
+   "execution_count": 13
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-04T21:26:15.934569Z",
+     "start_time": "2024-12-04T21:26:12.823775Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "# Example usage 2\n",
+    "question = \"What are the purposes of the 2015 Metro Vancouver Transportation and Transit Plebiscite event?\"\n",
+    "answer = rag_application.run(question)\n",
+    "print(\"Question:\", question)\n",
+    "print(\"Answer:\", answer)"
+   ],
+   "id": "5e6401026101ccc",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Document 0: page_content='body: Comparative Perspectives on Planning History and Futures [PLAN 500]School of Community and Regional Planning | UBCPARTICIPATORY PLANNING ANALYSISAaron Li, Erin Grace, Charlotte Lemieux, Jamie Tseng, Emily (Young Eun) Park, Brandon ChowIntroductionThe 2015 Metro Vancouver Transportation and Transit Plebiscite was a significant event in the region's political history. It arose from a campaign promise by the British Columbia Liberal Party led by Premier Christy Clark. The decision to hold a public vote on transportation funding was an unusual case in the context of Canadian governance, as major public infrastructure projects are seldom decided by a plebiscite or referendum. This move was seen as controversial, generating debate over the appropriateness of placing complex infrastructure planning in the hands of the general public.This plebiscite is unique in the history of public participation and will be critically analyzed using Fung’s Democracy Cube (2006) and Arnstein’s Ladder of Citizen Participation, highlighting the shortfalls and missed opportunities to ensure robust, equal, and deep participation.Scope and PlanThe proposed projects under the plebiscite were diverse and aimed at enhancing the transportation network within Metro Vancouver,including the expansion of the light rail network, such as the Broadway Subway project and Light Rail Transit (LRT) in Surrey and Langley, enhancements to existing bus services, a new 4-lane Pattullo Bridge, and significant upgrades to major roads (Mayors’ Council on Regional Transportation, 2015), as shown in Figure 1. These projects aimed to address the growing challenges of the region, specifically around transportation, transit, and congestion, with the goal to enhance connectivity and facilitate smoother commutes for residents.Figure 1. Proposed projects for transportation investmentImage from Mayors’ Council on Regional Transportation, 2015Controversial Funding MechanismThe funding mechanism proposed for these' metadata={'source': 'combined_excel.csv', 'row': 2147, 'start_index': 17}\n",
+      "Document 1: page_content='electorate's concerns over increased taxation, hesitation to absorb additional financial stress, and a lack of confidence in TransLink to effectively manage and execute the proposed improvements. The rejection prompted further discussions about funding mechanisms for public transportation projects, signifying the critical role of public participation in complex infrastructure decision-making.ProcessElections BC was responsible for the execution of the 2015 plebiscite, which cost almost $5.4 million dollars (Elections BC, 2015a) and was initiated on February 12, 2015, when the Plebiscite Regulation was established (Elections BC, 2015a). The entire process of the plebiscite started on March 16, 2015, when voting package distribution began; only registered BC voters were eligible to participate. The voting method was through mail-in ballots that voters would mark and send either directly to Elections BC or through a plebiscite service office. The number of registered voters was 1,551,507 at the initial package distribution date. The initial distribution was fully delivered to all voters by March 27.The 2015 plebiscite was the first one of its kind administered by Elections BC since the 1972 “British Columbia Time Plebiscite,” which was held simultaneously with a general election where voters were asked if they were in favour of Pacific Standard Time, including Pacific Daylight Savings time. The 2015 campaign was open to 23 municipalities in the Metro Vancouver Regional District, and residents were strongly encouraged to register to vote before and during the plebiscite as they would not be eligible to participate if they were not registered to vote in the province.There were nine service offices dedicated to providing services, guidance, and registration of new voters during the voting process. They were dispersed throughout different Metro Vancouver shopping centers. Elections BC operators were available six days a week, and contact hours were extended until midnight' metadata={'source': 'combined_excel.csv', 'row': 2147, 'start_index': 3609}\n",
+      "Document 2: page_content='residents.Figure 1. Proposed projects for transportation investmentImage from Mayors’ Council on Regional Transportation, 2015Controversial Funding MechanismThe funding mechanism proposed for these ambitious projects was a controversial component of the plebiscite. The question on the plebiscite ballot read:“Do you support a new 0.5% Metro Vancouver Congestion Improvement Tax, to be dedicated to the Mayors’ Council transportation and transit plan?”(Election BC, 2015a, p. 3).This tax increase was proposed to be included in BC sales tax and was projected to raise about $250 million annually (  Pawson  , 2015). The plebiscite being funded by an increase in sales tax was not popular among many voters, and other issues were raised around cost-effectiveness, the additional financial burden in a region already known for its high cost of living, and the evaluation of long-term economic benefits. It also raised the fundamental question of how the tax increase would disproportionately affect lower-income individuals and families who already spend a larger portion of their income on taxable goods and services.Furthermore, the plebiscite served as a referendum on the public’s trust in TransLink, the regional transportation authority responsible for the planning and management of transportation within Metro Vancouver. TransLink has faced extensive public criticism over its management, operational efficiency, and transparency issues. Therefore, the debate during the plebiscite often shifted focus from the proposed infrastructure improvements to the ability and credibility of TransLink to implement these plans effectively.The result of the plebiscite was ultimately a rejection by the voters, with 61.38% voting “no” and 38.32% “yes” (Election BC, 2015b). This outcome reflected the electorate's concerns over increased taxation, hesitation to absorb additional financial stress, and a lack of confidence in TransLink to effectively manage and execute the proposed improvements. The' metadata={'source': 'combined_excel.csv', 'row': 2147, 'start_index': 1813}\n",
+      "Document 3: page_content='studying a region that encompasses territories with different populations, land use, transportation infrastructure, and more. As shown in Figure 1, the Majors’ Council investment plan is not equally distributed across Metro Vancouver. Mobility needs vary locally. Proposing a regional strategy to meet local needs can be a complex task. The percentage of citizens who voted in favour of a tax dedicated to transportation investments varies significantly from municipality to municipality, as shown in Figure 4. We note a higher approval rate for municipalities near the city centre where more investments were proposed, including the Broadway Subway extension. Peterson et al. (2008) examined the spatial patterns of votes in the 2002 Seattle Monorail Referendum, which proposed funding for the project by raising the automobile registration tax. Their findings indicated that individuals living near the proposed line were more inclined to vote in favour of the increased tax.Figure 8. Percentage of citizens who voted for a tax increase per municipality. Created by Charlotte Lemieux, 2023.While regional planning might be necessary for establishing a connected public transportation network across multiple regions, the way of involving the population in the planning process must be adapted based on the phase of the decision-making process. In the studied case, it would probably have been preferable to employ a participatory process when defining the investment plan to determine the necessary projects at local and regional levels. We believe that the population might not possess the knowledge to decide whether this plan should be funded by a tax across the entire Metro Vancouver. The question regarding who should bear the costs for these infrastructures, mainly whether municipalities without proposed investments should fund projects in other municipalities, remains a significant concern. Indeed, such inquiries frequently arise when discussing taxation. Several projects require' metadata={'source': 'combined_excel.csv', 'row': 2147, 'start_index': 23379}\n",
+      "Question: What are the purposes of the 2015 Metro Vancouver Transportation and Transit Plebiscite event?\n",
+      "Answer: The purposes of the 2015 Metro Vancouver Transportation and Transit Plebiscite event were to:\n",
+      "\n",
+      "1. Gather public opinion on a new 0.5% Metro Vancouver Congestion Improvement Tax, which would be dedicated to the Mayors' Council transportation and transit plan.\n",
+      "2. Provide funding for various transportation projects, including the expansion of the light rail network, enhancements to existing bus services, a new 4-lane Pattullo Bridge, and significant upgrades to major roads.\n",
+      "3. Address the growing challenges of the region, specifically around transportation, transit, and congestion, with the goal to enhance connectivity and facilitate smoother commutes for residents.\n",
+      "\n",
+      "The plebiscite was also seen as an opportunity to evaluate public trust in TransLink, the regional transportation authority responsible for planning and managing transportation within Metro Vancouver.\n"
+     ]
+    }
+   ],
+   "execution_count": 16
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-04T21:31:24.400689Z",
+     "start_time": "2024-12-04T21:31:17.504671Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "# Example usage 3\n",
+    "question = \"What are the outcomes of the 2015 Metro Vancouver Transportation and Transit Plebiscite event?\"\n",
+    "answer = rag_application.run(question)\n",
+    "print(\"Question:\", question)\n",
+    "print(\"Answer:\", answer)"
+   ],
+   "id": "164d9786a7d45ad1",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Document 0: page_content='body: Comparative Perspectives on Planning History and Futures [PLAN 500]School of Community and Regional Planning | UBCPARTICIPATORY PLANNING ANALYSISAaron Li, Erin Grace, Charlotte Lemieux, Jamie Tseng, Emily (Young Eun) Park, Brandon ChowIntroductionThe 2015 Metro Vancouver Transportation and Transit Plebiscite was a significant event in the region's political history. It arose from a campaign promise by the British Columbia Liberal Party led by Premier Christy Clark. The decision to hold a public vote on transportation funding was an unusual case in the context of Canadian governance, as major public infrastructure projects are seldom decided by a plebiscite or referendum. This move was seen as controversial, generating debate over the appropriateness of placing complex infrastructure planning in the hands of the general public.This plebiscite is unique in the history of public participation and will be critically analyzed using Fung’s Democracy Cube (2006) and Arnstein’s Ladder of Citizen Participation, highlighting the shortfalls and missed opportunities to ensure robust, equal, and deep participation.Scope and PlanThe proposed projects under the plebiscite were diverse and aimed at enhancing the transportation network within Metro Vancouver,including the expansion of the light rail network, such as the Broadway Subway project and Light Rail Transit (LRT) in Surrey and Langley, enhancements to existing bus services, a new 4-lane Pattullo Bridge, and significant upgrades to major roads (Mayors’ Council on Regional Transportation, 2015), as shown in Figure 1. These projects aimed to address the growing challenges of the region, specifically around transportation, transit, and congestion, with the goal to enhance connectivity and facilitate smoother commutes for residents.Figure 1. Proposed projects for transportation investmentImage from Mayors’ Council on Regional Transportation, 2015Controversial Funding MechanismThe funding mechanism proposed for these' metadata={'source': 'combined_excel.csv', 'row': 2147, 'start_index': 17}\n",
+      "Document 1: page_content='electorate's concerns over increased taxation, hesitation to absorb additional financial stress, and a lack of confidence in TransLink to effectively manage and execute the proposed improvements. The rejection prompted further discussions about funding mechanisms for public transportation projects, signifying the critical role of public participation in complex infrastructure decision-making.ProcessElections BC was responsible for the execution of the 2015 plebiscite, which cost almost $5.4 million dollars (Elections BC, 2015a) and was initiated on February 12, 2015, when the Plebiscite Regulation was established (Elections BC, 2015a). The entire process of the plebiscite started on March 16, 2015, when voting package distribution began; only registered BC voters were eligible to participate. The voting method was through mail-in ballots that voters would mark and send either directly to Elections BC or through a plebiscite service office. The number of registered voters was 1,551,507 at the initial package distribution date. The initial distribution was fully delivered to all voters by March 27.The 2015 plebiscite was the first one of its kind administered by Elections BC since the 1972 “British Columbia Time Plebiscite,” which was held simultaneously with a general election where voters were asked if they were in favour of Pacific Standard Time, including Pacific Daylight Savings time. The 2015 campaign was open to 23 municipalities in the Metro Vancouver Regional District, and residents were strongly encouraged to register to vote before and during the plebiscite as they would not be eligible to participate if they were not registered to vote in the province.There were nine service offices dedicated to providing services, guidance, and registration of new voters during the voting process. They were dispersed throughout different Metro Vancouver shopping centers. Elections BC operators were available six days a week, and contact hours were extended until midnight' metadata={'source': 'combined_excel.csv', 'row': 2147, 'start_index': 3609}\n",
+      "Document 2: page_content='residents.Figure 1. Proposed projects for transportation investmentImage from Mayors’ Council on Regional Transportation, 2015Controversial Funding MechanismThe funding mechanism proposed for these ambitious projects was a controversial component of the plebiscite. The question on the plebiscite ballot read:“Do you support a new 0.5% Metro Vancouver Congestion Improvement Tax, to be dedicated to the Mayors’ Council transportation and transit plan?”(Election BC, 2015a, p. 3).This tax increase was proposed to be included in BC sales tax and was projected to raise about $250 million annually (  Pawson  , 2015). The plebiscite being funded by an increase in sales tax was not popular among many voters, and other issues were raised around cost-effectiveness, the additional financial burden in a region already known for its high cost of living, and the evaluation of long-term economic benefits. It also raised the fundamental question of how the tax increase would disproportionately affect lower-income individuals and families who already spend a larger portion of their income on taxable goods and services.Furthermore, the plebiscite served as a referendum on the public’s trust in TransLink, the regional transportation authority responsible for the planning and management of transportation within Metro Vancouver. TransLink has faced extensive public criticism over its management, operational efficiency, and transparency issues. Therefore, the debate during the plebiscite often shifted focus from the proposed infrastructure improvements to the ability and credibility of TransLink to implement these plans effectively.The result of the plebiscite was ultimately a rejection by the voters, with 61.38% voting “no” and 38.32% “yes” (Election BC, 2015b). This outcome reflected the electorate's concerns over increased taxation, hesitation to absorb additional financial stress, and a lack of confidence in TransLink to effectively manage and execute the proposed improvements. The' metadata={'source': 'combined_excel.csv', 'row': 2147, 'start_index': 1813}\n",
+      "Document 3: page_content='process, it was accessible to all eligible voters, fostering inclusivity and voluntary participation and allowing for widespread participation. However, the tendency for those with more significant resources or vested interests to engage more actively could lead to an underrepresented number of the broader population, a point that subsequent analysis will further discuss. Also, the plebiscite not only allowed for self-selection but also engaged the \"Diffuse Public Sphere\" through extensive public involvement. The extensive conversation across multiple media and platforms, as previously detailed, reduced participation barriers and allowed an exchange of ideas among the public. However, in contrast to the usual activities within the “Diffuse Public Sphere” that tend to influence discussions without direct or formal policy changes, the outcomes of the plebiscite had a significant and immediate effect on policy decisions. In summary, the 2015 Metro Vancouver Transportation and Transit Plebiscite’s participant selection process showcased a blend of inclusive, direct democracy and dynamic civic engagement.Modes of Communication and DecisionThe modes of communication and decision-making align with Fung’s (2006) \"Aggregate and Bargain\" mode. The primary reason is the plebiscite's foundational mechanism for establishing public preferences through a majority vote that transforms individual choices into collective decisions. Every vote cast by a participant directly impacted the outcome, reflecting an issue-specific form of public participation in policymaking. Again, the bargaining component was evident in the extensive public discourse across various platforms, including news, social media, forums like Reddit, and blogs, which aided participants in determining their decisions. While these discussions did not directly alter the plebiscite's outcome in a formal sense, they played a crucial role in shaping public opinion, facilitating the exchange of ideas, and developing a' metadata={'source': 'combined_excel.csv', 'row': 2147, 'start_index': 12592}\n",
+      "Question: What are the outcomes of the 2015 Metro Vancouver Transportation and Transit Plebiscite event?\n",
+      "Answer: The outcomes of the 2015 Metro Vancouver Transportation and Transit Plebiscite event were:\n",
+      "\n",
+      "* A total of 1,551,507 registered voters participated in the plebiscite.\n",
+      "* The question on the ballot was: \"Do you support a new 0.5% Metro Vancouver Congestion Improvement Tax, to be dedicated to the Mayors’ Council transportation and transit plan?\"\n",
+      "* The result of the plebiscite was ultimately a rejection by the voters, with 61.38% voting \"no\" and 38.32% \"yes\".\n",
+      "* The rejection reflected the electorate's concerns over increased taxation, hesitation to absorb additional financial stress, and a lack of confidence in TransLink to effectively manage and execute the proposed improvements.\n",
+      "* The plebiscite cost almost $5.4 million dollars (Elections BC, 2015a) and was seen as an unusual case in Canadian governance, where major public infrastructure projects are seldom decided by a plebiscite or referendum.\n",
+      "\n",
+      "Note: The question did not ask for specific outcomes of the proposed projects, but rather the funding mechanism itself.\n"
+     ]
+    }
+   ],
+   "execution_count": 17
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-04T21:37:36.546119Z",
+     "start_time": "2024-12-04T21:37:29.225424Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "# Example usage 4\n",
+    "question = \"What participation methods are used in the Participatory Planning in the Sidewalk Toronto Project?\"\n",
+    "answer = rag_application.run(question)\n",
+    "print(\"Question:\", question)\n",
+    "print(\"Answer:\", answer)"
+   ],
+   "id": "7a84892ca57357a9",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Document 0: page_content='from different segments of Toronto's population. The Resident Reference Panels allowed for structured feedback on key aspects of the project, including data governance, public space design, and environmental sustainability. Design Jams were creative sessions aimed at collaboratively brainstorming innovative solutions for the project. The Fellows Program was an initiative aimed at engaging young professionals to contribute to the project’s development process. Neighbourhood Meetings provided a forum for local residents to engage directly with project leaders, ensuring that those most affected by the project had their voices heard [3].Public ConsultationsPublic Consultations were a critical component of the Sidewalk Toronto project, designed to capture a broad spectrum of community input. These consultations were structured to include presentations by project leaders, followed by breakout sessions where participants could discuss specific topics in smaller groups. A variety of tools were used during these consultations, including feedback forms, discussion guides, and interactive activities that allowed participants to engage deeply with the topics at hand [4].Public RoundtablesPublic Roundtables were open forums that provided an opportunity for residents to engage in in-depth discussions on specific aspects of the project. These events were designed to be accessible to a broad audience, with sessions held in various locations across the city. The roundtables were structured to allow for both group discussions and plenary sessions where feedback could be shared with all participants [5].Town HallsTown Halls were a cornerstone of the public consultation process, providing a direct channel for residents to voice their opinions and concerns to project leaders. Multiple town halls were held at different locations across Toronto to ensure accessibility. Each town hall included presentations by representatives from Sidewalk Labs and Waterfront Toronto, followed by' metadata={'source': 'combined_excel.csv', 'row': 2224, 'start_index': 5414}\n",
+      "Document 1: page_content='democracy. MASS LBP was instrumental in managing the sortition process and facilitating the panel discussions, ensuring that the panels were both representative and effective [14].  What Went On: Process, Interaction, and Participation  The Sidewalk Toronto project involved multiple phases of public participation, each offering unique opportunities for interaction and feedback that were crucial in shaping the project's trajectory and addressing community concerns. The initial phase of citizen engagement commenced shortly after the project's official announcement in late 2017, when Waterfront Toronto and Sidewalk Labs organized a series of public consultations, town halls, and roundtable meetings across the city. These early engagements were primarily focused on introducing the project to the public, gathering preliminary feedback, and laying the groundwork for more detailed deliberations.  The various public participation methods, including Neighbourhood Meetings, Resident Reference Panels (RRP), and the Fellows Program, each had distinct characteristics and impacts on the project. The Neighbourhood Meetings in Quayside, for instance, were composed of presentations and Q&amp;A sessions where citizens could only contribute feedback by tagging it onto their questions. This format limited the ability of participants to offer detailed opinions and proposals, thereby diminishing their influence on the smart city project. In contrast, the RRP and Fellows Program offered more comprehensive opportunities for citizen involvement. These programs allowed participants to engage in extended discussions and co-write detailed reports with specific recommendations for Quayside, enhancing their capacity to influence the project's direction.  The Resident Reference Panels were particularly instrumental in gathering detailed feedback from a representative cross-section of Toronto’s residents. These panels were designed to provide a structured environment where participants could' metadata={'source': 'combined_excel.csv', 'row': 2224, 'start_index': 10802}\n",
+      "Document 2: page_content='Resources: methods\n",
+      "body: Problems and Purpose  Participatory urban planning directly engages neighbourhood residents in the process of land use planning. Residents provide local knowledge and information to compliment the technical know-how of experts and officials. Solutions are collectively developed to meet the needs of the community.  Participatory urban planning transforms neighborhoods and cities through an inclusive process using various methods and tools of participation and public engagement.  Origins and Development  Participant Recruitment and Selection  How it Works: Process, Interaction, and Decision-Making  Influence, Outcomes, and Effects  Analysis and Lessons Learned  See Also  References  External Links  Report by the Montreal Urban Ecology Centre (Centre d'écologie urbaine de Montréal) [FRENCH]:  https://www.ecologieurbaine.net/fr/boutique-en-ligne/detail/guide-urbanisme-participatif/17644Notes\n",
+      "row_number: 188' metadata={'source': 'combined_excel.csv', 'row': 2415, 'start_index': 0}\n",
+      "Document 3: page_content='newspaper.  For the July 2019 Public Consultation there were four avenues for participation: seven identical drop-in information sessions at various libraries; four identical public meetings held at separate venues; an online survey launched twenty days prior; and written submissions. The estimated participatory figures were 200 attendants for the drop-in sessions, 600 attendants for the public meetings, 200 responses for the online survey, and 34 written submissions, totalling at 1,034 estimated total participations during the public consultation process. Each public meeting saw at least 10-15% of individuals in attendance that had never been to a discussion related to Sidewalk Toronto [8].  Alongside its open invite, the 2017 Community Town Hall also involved a google form that allowed those that couldn’t attend or watch the livestream submit questions, which reached 5,538 people and received 67 comments, questions, and concerns. This event had in excess of 530 attendees and 3000 online viewers. The 4th Public Roundtable in 2018 saw similar numbers, with over 500 in-person participants and over 3500 viewers on the event livestream [9][10].  Organizing, Supporting, and Funding Entities  Most of the participatory planning methods were generally supported and facilitated by Waterfront Toronto and Sidewalk Labs. These organizations provided the necessary logistical support, including venue arrangements and the dissemination of materials. Financial resources were primarily provided by Sidewalk Labs, while local community organizations contributed to participant mobilization and ensuring diverse attendance [11][12][13]. The Resident Reference Panels were organized in collaboration with MASS LBP, a Canadian organization specializing in public engagement and deliberative democracy. MASS LBP was instrumental in managing the sortition process and facilitating the panel discussions, ensuring that the panels were both representative and effective [14].  What Went On:' metadata={'source': 'combined_excel.csv', 'row': 2224, 'start_index': 9006}\n",
+      "Question: What participation methods are used in the Participatory Planning in the Sidewalk Toronto Project?\n",
+      "Answer: The participation methods used in the Participatory Planning in the Sidewalk Toronto Project include:\n",
+      "\n",
+      "1. Resident Reference Panels (RRP): Structured feedback sessions where participants could discuss specific topics in smaller groups.\n",
+      "2. Design Jams: Creative sessions aimed at collaboratively brainstorming innovative solutions for the project.\n",
+      "3. Fellows Program: An initiative that engaged young professionals to contribute to the project’s development process.\n",
+      "4. Neighbourhood Meetings: Forums for local residents to engage directly with project leaders and share their opinions and concerns.\n",
+      "5. Public Consultations: Structured events where participants could discuss specific topics in smaller groups, including feedback forms, discussion guides, and interactive activities.\n",
+      "6. Public Roundtables: Open forums that provided an opportunity for residents to engage in in-depth discussions on specific aspects of the project.\n",
+      "7. Town Halls: Direct channels for residents to voice their opinions and concerns to project leaders.\n",
+      "8. Online surveys and written submissions: Digital avenues for participants to provide feedback, such as online forms, surveys, or written comments.\n",
+      "\n",
+      "These participation methods were used throughout the project's various phases, including public consultations, town halls, roundtables, and design jams, to gather feedback from a diverse range of stakeholders and ensure that the project was inclusive and representative of the community.\n"
+     ]
+    }
+   ],
+   "execution_count": 18
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-04T21:44:54.465942Z",
+     "start_time": "2024-12-04T21:44:48.652889Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "# Example usage 5\n",
+    "question = \"What are the purposes of the Participatory Planning in the Sidewalk Toronto Project?\"\n",
+    "answer = rag_application.run(question)\n",
+    "print(\"Question:\", question)\n",
+    "print(\"Answer:\", answer)"
+   ],
+   "id": "c4ab52b5a8a1e36a",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Document 0: page_content='from different segments of Toronto's population. The Resident Reference Panels allowed for structured feedback on key aspects of the project, including data governance, public space design, and environmental sustainability. Design Jams were creative sessions aimed at collaboratively brainstorming innovative solutions for the project. The Fellows Program was an initiative aimed at engaging young professionals to contribute to the project’s development process. Neighbourhood Meetings provided a forum for local residents to engage directly with project leaders, ensuring that those most affected by the project had their voices heard [3].Public ConsultationsPublic Consultations were a critical component of the Sidewalk Toronto project, designed to capture a broad spectrum of community input. These consultations were structured to include presentations by project leaders, followed by breakout sessions where participants could discuss specific topics in smaller groups. A variety of tools were used during these consultations, including feedback forms, discussion guides, and interactive activities that allowed participants to engage deeply with the topics at hand [4].Public RoundtablesPublic Roundtables were open forums that provided an opportunity for residents to engage in in-depth discussions on specific aspects of the project. These events were designed to be accessible to a broad audience, with sessions held in various locations across the city. The roundtables were structured to allow for both group discussions and plenary sessions where feedback could be shared with all participants [5].Town HallsTown Halls were a cornerstone of the public consultation process, providing a direct channel for residents to voice their opinions and concerns to project leaders. Multiple town halls were held at different locations across Toronto to ensure accessibility. Each town hall included presentations by representatives from Sidewalk Labs and Waterfront Toronto, followed by' metadata={'source': 'combined_excel.csv', 'row': 2224, 'start_index': 5414}\n",
+      "Document 1: page_content='democracy. MASS LBP was instrumental in managing the sortition process and facilitating the panel discussions, ensuring that the panels were both representative and effective [14].  What Went On: Process, Interaction, and Participation  The Sidewalk Toronto project involved multiple phases of public participation, each offering unique opportunities for interaction and feedback that were crucial in shaping the project's trajectory and addressing community concerns. The initial phase of citizen engagement commenced shortly after the project's official announcement in late 2017, when Waterfront Toronto and Sidewalk Labs organized a series of public consultations, town halls, and roundtable meetings across the city. These early engagements were primarily focused on introducing the project to the public, gathering preliminary feedback, and laying the groundwork for more detailed deliberations.  The various public participation methods, including Neighbourhood Meetings, Resident Reference Panels (RRP), and the Fellows Program, each had distinct characteristics and impacts on the project. The Neighbourhood Meetings in Quayside, for instance, were composed of presentations and Q&amp;A sessions where citizens could only contribute feedback by tagging it onto their questions. This format limited the ability of participants to offer detailed opinions and proposals, thereby diminishing their influence on the smart city project. In contrast, the RRP and Fellows Program offered more comprehensive opportunities for citizen involvement. These programs allowed participants to engage in extended discussions and co-write detailed reports with specific recommendations for Quayside, enhancing their capacity to influence the project's direction.  The Resident Reference Panels were particularly instrumental in gathering detailed feedback from a representative cross-section of Toronto’s residents. These panels were designed to provide a structured environment where participants could' metadata={'source': 'combined_excel.csv', 'row': 2224, 'start_index': 10802}\n",
+      "Document 2: page_content='for increased pollution, the effects of construction on local ecosystems, and the sustainability of the proposed infrastructure. Recommendations included the adoption of green technologies, green building practices, waste management strategies, preservative measures for local wildlife habitats, renewable energy sources, and comprehensive environmental monitoring protocols.  The need for inclusive and accessible public spaces was a consistent priority. Participants emphasized that urban design should cater to the diverse needs of Toronto’s residents, including considerations for accessibility, cultural relevance, and safety. Suggestions were made for the creation of public spaces that were accessible and inclusive, with participants advocating for more green spaces, pedestrian-friendly areas, and community-focused amenities.Interaction and ResponseThe interactions between residents, community groups, government agencies, and Sidewalk Labs were central to the Sidewalk Toronto project. These interactions were characterized by a dynamic exchange of ideas, concerns, and recommendations, with participants often challenging project leaders on key issues and pushing for more transparency and accountability. One of the central tensions throughout the engagement process was the balancing of public and private interests. While Sidewalk Labs brought significant technological expertise and financial resources to the project, there was widespread concern about the level of corporate influence over public spaces and the potential for profit motives to overshadow community needs. These concerns were particularly acute in discussions around data governance and the commercialization of public space, with many participants advocating for stronger public control and oversight [16][17][18].Procedural ConcernsSeveral procedural issues were identified across the various citizen engagement methods. One significant challenge was the perceived imbalance in information provision. Many' metadata={'source': 'combined_excel.csv', 'row': 2224, 'start_index': 19799}\n",
+      "Document 3: page_content='body: Problems and Purpose  Toronto’s waterfront had been suffering from underdevelopment and a series of failed attempts to address growth struggles in the area. Sidewalk Labs on the other hand had been searching for an area where they could test their urban innovations, and as a large, diverse, and progressive city, Toronto seemed like an ideal location. The citizen engagement techniques used throughout the Sidewalk Toronto Project were designed to provide the initiative with a public mandate and avoid opposition through fostering a sense of community ownership by incorporating citizen proposals and projecting transparency [1].  Background History and Context  Toronto’s waterfront has long been a focal point for ambitious urban development, with plans to reshape this area dating back over five decades. These evolving plans reflect broader changes in Toronto’s economic and social landscape, particularly as the city transitioned away from its manufacturing and resource-based industries, which once dominated the waterfront. This shift revealed new opportunities for diverse economic activities and increased public access to the underutilized lands along the water's edge.  Historically, the city has witnessed three distinct eras of planning ambitions for the waterfront. Between 1960 and 1972, city planners envisioned a high-density, modernist project known as \"Harbor City,\" which sought to radically transform the area. By the mid-1970s, civic leaders shifted their focus away from grand master plans, opting instead for smaller-scale improvements aimed at enhancing the public realm, expanding parklands, and stimulating job growth in the eastern harbour. The period from 1988 to 2000 marked another transition, as the focus turned towards brownfield remediation, ecosystem restoration, and the promotion of mixed-use development. Despite the varying approaches across these eras, none of the plans came to full fruition due to a range of challenges, including legal disputes,' metadata={'source': 'combined_excel.csv', 'row': 2224, 'start_index': 17}\n",
+      "Question: What are the purposes of the Participatory Planning in the Sidewalk Toronto Project?\n",
+      "Answer: The purposes of Participatory Planning in the Sidewalk Toronto Project were to provide a public mandate for the initiative, foster a sense of community ownership by incorporating citizen proposals and projecting transparency, and avoid opposition through citizen engagement. The planning process involved various methods, such as Resident Reference Panels, Design Jams, Fellows Program, Neighbourhood Meetings, Public Consultations, Public Roundtables, and Town Halls, which allowed for structured feedback, creative brainstorming, and direct dialogue between project leaders and residents. These efforts aimed to capture a broad spectrum of community input on aspects like data governance, public space design, environmental sustainability, and urban infrastructure. The participatory planning process sought to balance public and private interests while ensuring that the needs and concerns of Toronto's diverse residents were addressed and integrated into the project's development process.\n"
+     ]
+    }
+   ],
+   "execution_count": 19
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-04T21:49:04.029749Z",
+     "start_time": "2024-12-04T21:48:59.823538Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "# Example usage 6\n",
+    "question = \"What are the outcomes of the Participatory Planning in the Sidewalk Toronto Project?\"\n",
+    "answer = rag_application.run(question)\n",
+    "print(\"Question:\", question)\n",
+    "print(\"Answer:\", answer)"
+   ],
+   "id": "a362aa60fbecdc69",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Document 0: page_content='from different segments of Toronto's population. The Resident Reference Panels allowed for structured feedback on key aspects of the project, including data governance, public space design, and environmental sustainability. Design Jams were creative sessions aimed at collaboratively brainstorming innovative solutions for the project. The Fellows Program was an initiative aimed at engaging young professionals to contribute to the project’s development process. Neighbourhood Meetings provided a forum for local residents to engage directly with project leaders, ensuring that those most affected by the project had their voices heard [3].Public ConsultationsPublic Consultations were a critical component of the Sidewalk Toronto project, designed to capture a broad spectrum of community input. These consultations were structured to include presentations by project leaders, followed by breakout sessions where participants could discuss specific topics in smaller groups. A variety of tools were used during these consultations, including feedback forms, discussion guides, and interactive activities that allowed participants to engage deeply with the topics at hand [4].Public RoundtablesPublic Roundtables were open forums that provided an opportunity for residents to engage in in-depth discussions on specific aspects of the project. These events were designed to be accessible to a broad audience, with sessions held in various locations across the city. The roundtables were structured to allow for both group discussions and plenary sessions where feedback could be shared with all participants [5].Town HallsTown Halls were a cornerstone of the public consultation process, providing a direct channel for residents to voice their opinions and concerns to project leaders. Multiple town halls were held at different locations across Toronto to ensure accessibility. Each town hall included presentations by representatives from Sidewalk Labs and Waterfront Toronto, followed by' metadata={'source': 'combined_excel.csv', 'row': 2224, 'start_index': 5414}\n",
+      "Document 1: page_content='democracy. MASS LBP was instrumental in managing the sortition process and facilitating the panel discussions, ensuring that the panels were both representative and effective [14].  What Went On: Process, Interaction, and Participation  The Sidewalk Toronto project involved multiple phases of public participation, each offering unique opportunities for interaction and feedback that were crucial in shaping the project's trajectory and addressing community concerns. The initial phase of citizen engagement commenced shortly after the project's official announcement in late 2017, when Waterfront Toronto and Sidewalk Labs organized a series of public consultations, town halls, and roundtable meetings across the city. These early engagements were primarily focused on introducing the project to the public, gathering preliminary feedback, and laying the groundwork for more detailed deliberations.  The various public participation methods, including Neighbourhood Meetings, Resident Reference Panels (RRP), and the Fellows Program, each had distinct characteristics and impacts on the project. The Neighbourhood Meetings in Quayside, for instance, were composed of presentations and Q&amp;A sessions where citizens could only contribute feedback by tagging it onto their questions. This format limited the ability of participants to offer detailed opinions and proposals, thereby diminishing their influence on the smart city project. In contrast, the RRP and Fellows Program offered more comprehensive opportunities for citizen involvement. These programs allowed participants to engage in extended discussions and co-write detailed reports with specific recommendations for Quayside, enhancing their capacity to influence the project's direction.  The Resident Reference Panels were particularly instrumental in gathering detailed feedback from a representative cross-section of Toronto’s residents. These panels were designed to provide a structured environment where participants could' metadata={'source': 'combined_excel.csv', 'row': 2224, 'start_index': 10802}\n",
+      "Document 2: page_content='for increased pollution, the effects of construction on local ecosystems, and the sustainability of the proposed infrastructure. Recommendations included the adoption of green technologies, green building practices, waste management strategies, preservative measures for local wildlife habitats, renewable energy sources, and comprehensive environmental monitoring protocols.  The need for inclusive and accessible public spaces was a consistent priority. Participants emphasized that urban design should cater to the diverse needs of Toronto’s residents, including considerations for accessibility, cultural relevance, and safety. Suggestions were made for the creation of public spaces that were accessible and inclusive, with participants advocating for more green spaces, pedestrian-friendly areas, and community-focused amenities.Interaction and ResponseThe interactions between residents, community groups, government agencies, and Sidewalk Labs were central to the Sidewalk Toronto project. These interactions were characterized by a dynamic exchange of ideas, concerns, and recommendations, with participants often challenging project leaders on key issues and pushing for more transparency and accountability. One of the central tensions throughout the engagement process was the balancing of public and private interests. While Sidewalk Labs brought significant technological expertise and financial resources to the project, there was widespread concern about the level of corporate influence over public spaces and the potential for profit motives to overshadow community needs. These concerns were particularly acute in discussions around data governance and the commercialization of public space, with many participants advocating for stronger public control and oversight [16][17][18].Procedural ConcernsSeveral procedural issues were identified across the various citizen engagement methods. One significant challenge was the perceived imbalance in information provision. Many' metadata={'source': 'combined_excel.csv', 'row': 2224, 'start_index': 19799}\n",
+      "Document 3: page_content='in projects involving significant private sector involvement.  Analysis of the Impact on Democratic Goods  The Sidewalk Toronto project was not only a test bed for new urban technologies but also a significant experiment in public participation. However, the project faced substantial challenges related to its democratic goods, as outlined by Graham Smith. The following analysis evaluates the project’s performance across key democratic goods, including inclusion, considered judgment, popular control, transparency, efficiency, and transferability [24].InclusionInclusion is a critical democratic good that refers to the ability of a process to engage a diverse and representative sample of the population. The Sidewalk Toronto project employed various participatory methods promoting inclusivity, such as Resident Reference Panels, Public Consultations, Town Halls, and Public Roundtables. These efforts were designed to engage a broad cross-section of Toronto’s population, including residents from diverse socio-economic backgrounds, young professionals, and community leaders, but their effectiveness was mixed. While the Resident Reference Panels were selected through a civic lottery, ensuring a degree of demographic representativeness, other methods like the Town Halls and Public Consultations relied on self-selection, which may have skewed participation towards more vocal and engaged citizens. Although this approach is inclusive in theory, may have excluded less confident or informed individuals who were less likely to participate actively. Some engagement methods, such as the Neighbourhood Meetings, were criticized for their limited format, which restricted participants' ability to provide detailed feedback.  The project claimed to make efforts to accommodate different participants by providing information sessions and materials to build capacity, withal the complexity of the issues at hand, particularly around data governance and the technical aspects of smart city' metadata={'source': 'combined_excel.csv', 'row': 2224, 'start_index': 30606}\n",
+      "Question: What are the outcomes of the Participatory Planning in the Sidewalk Toronto Project?\n",
+      "Answer: The outcomes of the Participatory Planning in the Sidewalk Toronto Project include:\n",
+      "\n",
+      "* A representative cross-section of Toronto's residents were engaged through the Resident Reference Panels (RRP), which provided a structured environment for detailed feedback.\n",
+      "* The RRP and Fellows Program allowed participants to engage in extended discussions and co-write reports with specific recommendations, enhancing their capacity to influence the project's direction.\n",
+      "* Recommendations made by participants included green technologies, sustainable building practices, waste management strategies, renewable energy sources, comprehensive environmental monitoring protocols, and more inclusive public spaces.\n",
+      "* Concerns around data governance, commercialization of public space, and corporate influence were raised by participants, pushing for stronger public control and oversight.\n",
+      "* Procedural concerns, such as the perceived imbalance in information provision and limited formats for participation (e.g., Neighbourhood Meetings), were identified across various citizen engagement methods.\n",
+      "\n",
+      "Overall, the Participatory Planning process in Sidewalk Toronto aimed to address community concerns, foster inclusive decision-making, and balance public and private interests. However, challenges related to democratic goods, such as inclusion and transparency, were also present throughout the project.\n"
+     ]
+    }
+   ],
+   "execution_count": 20
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": "",
+   "id": "b16026fd01e6e34b"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/chatbot/server.py
+++ b/chatbot/server.py
@@ -1,0 +1,63 @@
+from langchain_ollama import ChatOllama, OllamaEmbeddings
+import faiss
+from langchain_community.vectorstores import FAISS
+from langchain.prompts import PromptTemplate
+from langchain_core.output_parsers import StrOutputParser
+from flask import Flask, request
+
+
+# Use Meta Llama 3.1 8B Instruct as the chat model
+llm = ChatOllama(model="llama3.1")
+
+# Use mxbai-embed-large as the embedding model
+embeddings = OllamaEmbeddings(model="mxbai-embed-large")
+
+# use a single GPU for similarity search
+res = faiss.StandardGpuResources()
+# load the previously cached FAISS index
+vector_store = FAISS.load_local("faiss_index", embeddings, allow_dangerous_deserialization=True)
+# convert the index from cpu-based to gpu-based for accelerated search
+vector_store.index = faiss.index_cpu_to_gpu(res, 0, vector_store.index)
+# use FAISS indexed vector store as the retriever
+retriever = vector_store.as_retriever()
+
+# Define the prompt template for the LLM
+prompt = PromptTemplate(
+    template="""You are an assistant for question-answering tasks.
+    Use the following documents to answer the question.
+    If you don't know the answer, just say that you don't know.
+    Question: {question}
+    Documents: {documents}
+    Answer:
+    """,
+    input_variables=["question", "documents"],
+)
+
+# Create a chain combining the prompt template and LLM
+rag_chain = prompt | llm | StrOutputParser()
+
+# Define the RAG application class
+class RAGApplication:
+    def __init__(self, retriever, rag_chain):
+        self.retriever = retriever
+        self.rag_chain = rag_chain
+    def run(self, question):
+        # Retrieve relevant documents
+        documents = self.retriever.invoke(question)
+        # Extract content from retrieved documents
+        doc_texts = "\\n".join([doc.page_content for doc in documents])
+        # Get the answer from the language model
+        answer = self.rag_chain.invoke({"question": question, "documents": doc_texts})
+        return answer
+
+app = Flask(__name__)
+
+@app.route('/ask', methods=['POST'])
+def ask():
+    # Initialize the RAG application
+    rag_application = RAGApplication(retriever, rag_chain)
+    # Obtain the question
+    question = request.json['question']
+    # Get the answer
+    answer = rag_application.run(question)
+    return {'answer': answer}


### PR DESCRIPTION
This RAG uses Meta Llama 3.1 8B Instruct as the LLM, mxbai-embed-large as the embedding model, and FAISS as the vector store. The models are run by Ollama, and the entire RAG process is set up using LangChain. The frontend is built with Gradio.